### PR TITLE
Update init-app to use fastly/js-compute version 2.0.0

### DIFF
--- a/src/cli/commands/init-app.ts
+++ b/src/cli/commands/init-app.ts
@@ -492,7 +492,7 @@ export function initApp(commandLineValues: CommandLineOptions) {
       '@fastly/compute-js-static-publish': computeJsStaticPublisherVersion,
     },
     dependencies: {
-      '@fastly/js-compute': '^1.4.0',
+      '@fastly/js-compute': '^2.0.0',
     },
     engines: {
       node: '>=18.0.0',


### PR DESCRIPTION
Running the `npx @fastly/compute-js-static-publish@latest --root-dir=./public` currently creates a project with `fastly/js-compute` version 1.4 in the package.json which ends up causing an error when `npm install && fastly compute serve`

```
✘ [ERROR] Do not know how to load path: fastly:kv-store

    node_modules/@fastly/compute-js-static-publish/build/server/assets/content-asset-kv-store.js:1:24:
      1 │ import { KVStore } from "fastly:kv-store";
        ╵                         ~~~~~~~~~~~~~~~~~
````

This just bumps the js-compute version up to 2.0.0 where KVStore is available.