### PR TITLE
fix: Windows compatibility issues

### DIFF
--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -290,7 +290,9 @@ export async function buildStaticLoader(commandLineValues: commandLineArgs.Comma
 
   // And then we apply assetInclusionTest.
   const assetInfos: AssetInfo[] = files.map(file => {
-    const assetKey = file.slice(publicDirRoot.length);
+    const assetKey = file.slice(publicDirRoot.length)
+      // in Windows, assetKey will otherwise end up as \path\file.html
+      .replace(/\\/g, '/');
 
     let contentTypeTestResult = testFileContentType(finalContentTypes, assetKey);
 

--- a/src/cli/load-config.ts
+++ b/src/cli/load-config.ts
@@ -1,3 +1,4 @@
+import url from "url";
 import path from "path";
 import globToRegExp from 'glob-to-regexp';
 
@@ -363,10 +364,11 @@ export async function loadConfigFile(errors: string[] = []): Promise<{normalized
 
   let raw: any = undefined;
   const staticPublishRcPath = path.resolve('./static-publish.rc.js');
+  const staticPublishRcFileURL = url.pathToFileURL(staticPublishRcPath).toString()
   try {
-    raw = (await import(staticPublishRcPath)).default;
+    raw = (await import(staticPublishRcFileURL)).default;
   } catch {
-    errors.push('Unable to load ' + staticPublishRcPath);
+    errors.push('Unable to load ' + staticPublishRcFileURL);
   }
 
   let normalized: any = undefined;


### PR DESCRIPTION
Hi!

While I'm not a Windows user, I have some colleagues at IKEA who have bumped into issues with this library. It's the same underlying issue that caused https://github.com/fastly/next-compute-js/issues/1

I've added two fixes that makes this library work on Windows:

### 1. await import()

`await import()` doesn't seem to work when you use an absolute path like `C:\Users\Johan\IKEA-PROJECT\compute-js\static-publish.rc.js`. You'll get the following error:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

The solution is https://nodejs.org/api/url.html#url_url_pathtofileurl_path. The path then becomes `file:///C:/Users/Johan/IKEA-PROJECT/compute-js/static-publish.rc.js`.

### 2. \path\to\file.css vs. /path/to/file.css

assetKeys end up with `\` in Windows, so request URLs never match against any assets.

Feel free to incorporate these changes any way you see fit!