### PR TITLE
fix: allow for dots in KV Store name

### DIFF
--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -143,6 +143,8 @@ function writeKVStoreEntriesToFastlyToml(kvStoreName: string, kvStoreItems: KVSt
   let before: string = '';
   let after: string = '';
 
+  kvStoreName = kvStoreName.includes(".") ? `"${kvStoreName}"` : kvStoreName;
+
   const tableMarker = `[[local_server.kv_stores.${kvStoreName}]]`;
 
   const startPos = fastlyToml.indexOf(tableMarker);
@@ -152,7 +154,8 @@ function writeKVStoreEntriesToFastlyToml(kvStoreName: string, kvStoreItems: KVSt
 
     if (fastlyToml.indexOf(kvStoreName) !== -1) {
       // don't do this!
-      console.error("Don't do this!");
+      console.error("improperly configured entry for '${kvStoreName}' in fastly.toml");
+      // TODO: handle thrown exception from callers
       throw "No"!
     }
 


### PR DESCRIPTION
Fastly allows for special characters (like `.`) in the KV store name, but since the configuration is in toml, these characters need to be either escaped, or wrapped in quotes to be treated as a single string rather than configuration.

This change wraps the kvStoreName variable in double quotes to prevent toml interpolating the name.

Example error:

```
Don't do this!

node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^
No
(Use `node --trace-uncaught ...` to show where the exception was thrown)
```