### PR TITLE
fix: update instructions to use this repo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Now, each time you build this Compute project, `compute-js-static-publish` will 
 
 ```shell
 cd ./compute-js
-npm install
-npm run start
+fastly compute serve
 ```
 
 This will serve your application using the default `PublisherServer()`.
@@ -39,7 +38,7 @@ However, you can modify `/src/index.js` to add your own processing as you need. 
 ### 3. When you're ready to go live, [deploy your Compute service](https://developer.fastly.com/reference/cli/compute/publish/)
 
 ```shell
-npm run deploy
+fastly compute publish
 ```
 
 ## Features


### PR DESCRIPTION
I found the current instructions in README.md doesn't work in my environment. Below is the steps to repro;

```
$ mkdir /tmp/testdir && cd /tmp/testdir
$ mkdir public
$ echo "hello" > ./public/world.txt
$ npx @fastly/compute-js-static-publish@latest --root-dir=./public
$ cd ./compute-js
$ npm install     # nothing was installed
$ npm run start   # npm error Missing script: "start"
$ npm run deploy  # ERROR: error reading package size: stat pkg/compute-js-static-site.tar.gz: no such file or directory.
```

I used `fastly compute serve` and `fastly compute publish` to work around errors above, and looks it's working. These two commands are in fact shown after running ` npx @fastly/compute-js-static-publish@latest --root-dir=./public` command as follows;
```
...
🚀 Compute application created!
Installing dependencies...
npm --prefix ./compute-js install

added 116 packages, and audited 117 packages in 14s

24 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities


To run your Compute application locally:

  cd ./compute-js
  fastly compute serve

To build and deploy to your Compute service:

  cd ./compute-js
  fastly compute publish
```

So I thought it could be a good idea to use `fastly compute` commands instead of npm commands from a consistency point of view too.