### PR TITLE
Allow @fastly/compute-js-static-publish to be upgraded after app is scaffolded.

### DIFF
--- a/src/cli/commands/init-app.ts
+++ b/src/cli/commands/init-app.ts
@@ -531,7 +531,7 @@ ${staticFiles}
     type: 'module',
     devDependencies: {
       "@fastly/cli": "^10.14.0",
-      '@fastly/compute-js-static-publish': computeJsStaticPublisherVersion,
+      '@fastly/compute-js-static-publish': "^" + computeJsStaticPublisherVersion,
     },
     dependencies: {
       '@fastly/js-compute': '^3.0.0',


### PR DESCRIPTION
Without a prefixed version specifier, the scaffolded application will forever be pinned to the version which was used to create it.