### PR TITLE
Improve KV Store Publishing algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Using a static site generator to build your website? Do you simply need to serve
 
 ## Prerequisites
 
-Node 18 or newer is required during the build step, as we now rely on its `experimental-fetch` feature.
+Although your published application runs on a Fastly Compute service, the publishing process offered by this package requires Node.js 20 or newer.
 
 ## How it works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,12 @@
         "@fastly/js-compute": "^3.0.0",
         "@types/command-line-args": "^5.2.0",
         "@types/glob-to-regexp": "^0.4.1",
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.0.0",
         "rimraf": "^4.3.0",
         "typescript": "^5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@fastly/js-compute": "^2.0.0 || ^3.0.0"
@@ -1117,10 +1117,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "version": "20.17.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.27.tgz",
+      "integrity": "sha512-U58sbKhDrthHlxHRJw7ZLiLDZGmAUOZUbpw0S6nL27sYUdhvgBLCRu/keSd6qcTsfArd1sRFCCBxzWATGr/0UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -2368,6 +2372,13 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -3004,10 +3015,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-      "dev": true
+      "version": "20.17.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.27.tgz",
+      "integrity": "sha512-U58sbKhDrthHlxHRJw7ZLiLDZGmAUOZUbpw0S6nL27sYUdhvgBLCRu/keSd6qcTsfArd1sRFCCBxzWATGr/0UA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "acorn": {
       "version": "8.14.1",
@@ -3847,6 +3861,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "@fastly/js-compute": "^3.0.0",
     "@types/command-line-args": "^5.2.0",
     "@types/glob-to-regexp": "^0.4.1",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "rimraf": "^4.3.0",
     "typescript": "^5.0.2"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "build",

--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -128,11 +128,9 @@ type KVStoreItemDesc = {
 async function uploadFilesToKVStore(fastlyApiContext: FastlyApiContext, kvStoreName: string, kvStoreItems: KVStoreItemDesc[]) {
 
   const maxConcurrent = 12;
-  let index = 0;
+  let index = 0; // Shared among workers
 
   async function worker() {
-    // This loop is safe because JavaScript is single-threaded.
-    // Workers pull work one item at a time using a shared index.
     while (index < kvStoreItems.length) {
       const currentIndex = index;
       index = index + 1;

--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -194,7 +194,7 @@ function writeKVStoreEntriesToFastlyToml(kvStoreName: string, kvStoreItems: KVSt
 
     if (fastlyToml.indexOf(kvStoreName) !== -1) {
       // don't do this!
-      console.error("improperly configured entry for '${kvStoreName}' in fastly.toml");
+      console.error(`improperly configured entry for '${kvStoreName}' in fastly.toml`);
       // TODO: handle thrown exception from callers
       throw "No"!
     }

--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -68,7 +68,7 @@ import { applyDefaults } from "../util/data.js";
 import { calculateFileSizeAndHash } from "../util/hash.js";
 import { getFiles } from "../util/files.js";
 import { generateOrLoadPublishId } from "../util/publish-id.js";
-import { FastlyApiContext, loadApiKey } from "../util/fastly-api.js";
+import { FastlyApiContext, FetchError, loadApiKey } from "../util/fastly-api.js";
 import { kvStoreEntryExists, kvStoreSubmitFile } from "../util/kv-store.js";
 import { mergeContentTypes, testFileContentType } from "../../util/content-types.js";
 import { algs } from "../compression/index.js";
@@ -94,6 +94,9 @@ import type {
   ContentFileInfoForWasmInline,
   ContentFileInfoForKVStore,
 } from "../../types/content-assets.js";
+import {
+  attemptWithRetries,
+} from "../util/retryable.js";
 
 type AssetInfo =
   ContentTypeTestResult &
@@ -123,15 +126,54 @@ type KVStoreItemDesc = {
 };
 
 async function uploadFilesToKVStore(fastlyApiContext: FastlyApiContext, kvStoreName: string, kvStoreItems: KVStoreItemDesc[]) {
-  for (const { kvStoreKey, staticFilePath, text } of kvStoreItems) {
-    if (await kvStoreEntryExists(fastlyApiContext, kvStoreName, kvStoreKey)) {
-      console.log(`✔️ Asset already exists in KV Store with key "${kvStoreKey}".`);
-      continue;
+
+  const maxConcurrent = 12;
+  let index = 0;
+
+  async function worker() {
+    while (index < kvStoreItems.length) {
+      const currentIndex = index;
+      index = index + 1;
+      const { kvStoreKey, staticFilePath, text } = kvStoreItems[currentIndex];
+
+      try {
+        await attemptWithRetries(
+          async() => {
+            if (await kvStoreEntryExists(fastlyApiContext, kvStoreName, kvStoreKey)) {
+              console.log(`✔️ Asset already exists in KV Store with key "${kvStoreKey}".`);
+              return;
+            }
+            const fileData = fs.readFileSync(staticFilePath);
+            await kvStoreSubmitFile(fastlyApiContext, kvStoreName, kvStoreKey, fileData);
+            console.log(`✔️ Submitted ${text ? 'text' : 'binary'} asset "${staticFilePath}" to KV Store with key "${kvStoreKey}".`)
+          },
+          {
+            onAttempt(attempt) {
+              if (attempt > 0) {
+                console.log(`Attempt ${attempt + 1} for: ${kvStoreKey}`);
+              }
+            },
+            onRetry(attempt, err, delay) {
+              let statusMessage = 'unknown';
+              if (err instanceof FetchError) {
+                statusMessage = `HTTP ${err.status}`;
+              } else if (err instanceof TypeError) {
+                statusMessage = 'transport';
+              }
+              console.log(`Attempt ${attempt + 1} for ${kvStoreKey} gave retryable error (${statusMessage}), delaying ${delay} ms`);
+            },
+          }
+        );
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        console.error(`❌ Failed: ${kvStoreKey} → ${e.message}`);
+        console.error(e.stack);
+      }
     }
-    const fileData = fs.readFileSync(staticFilePath);
-    await kvStoreSubmitFile(fastlyApiContext!, kvStoreName!, kvStoreKey, fileData);
-    console.log(`✔️ Submitted ${text ? 'text' : 'binary'} asset "${staticFilePath}" to KV Store with key "${kvStoreKey}".`)
   }
+
+  const workers = Array.from({ length: maxConcurrent }, () => worker());
+  await Promise.all(workers);
 }
 
 function writeKVStoreEntriesToFastlyToml(kvStoreName: string, kvStoreItems: KVStoreItemDesc[]) {

--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -125,14 +125,12 @@ type KVStoreItemDesc = {
 async function uploadFilesToKVStore(fastlyApiContext: FastlyApiContext, kvStoreName: string, kvStoreItems: KVStoreItemDesc[]) {
   for (const { kvStoreKey, staticFilePath, text } of kvStoreItems) {
     if (await kvStoreEntryExists(fastlyApiContext, kvStoreName, kvStoreKey)) {
-      // Already exists in KV Store
-      console.log(`✔️ Asset already exists in KV Store with key "${kvStoreKey}".`)
-    } else {
-      // Upload to KV Store
-      const fileData = fs.readFileSync(staticFilePath);
-      await kvStoreSubmitFile(fastlyApiContext!, kvStoreName!, kvStoreKey, fileData);
-      console.log(`✔️ Submitted ${text ? 'text' : 'binary'} asset "${staticFilePath}" to KV Store with key "${kvStoreKey}".`)
+      console.log(`✔️ Asset already exists in KV Store with key "${kvStoreKey}".`);
+      continue;
     }
+    const fileData = fs.readFileSync(staticFilePath);
+    await kvStoreSubmitFile(fastlyApiContext!, kvStoreName!, kvStoreKey, fileData);
+    console.log(`✔️ Submitted ${text ? 'text' : 'binary'} asset "${staticFilePath}" to KV Store with key "${kvStoreKey}".`)
   }
 }
 

--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -131,6 +131,8 @@ async function uploadFilesToKVStore(fastlyApiContext: FastlyApiContext, kvStoreN
   let index = 0;
 
   async function worker() {
+    // This loop is safe because JavaScript is single-threaded.
+    // Workers pull work one item at a time using a shared index.
     while (index < kvStoreItems.length) {
       const currentIndex = index;
       index = index + 1;

--- a/src/cli/commands/init-app.ts
+++ b/src/cli/commands/init-app.ts
@@ -543,7 +543,7 @@ ${staticFiles}
       '@fastly/js-compute': '^3.0.0',
     },
     engines: {
-      node: '>=18.0.0',
+      node: '>=20.0.0',
     },
     license: 'UNLICENSED',
     private: true,

--- a/src/cli/util/kv-store.ts
+++ b/src/cli/util/kv-store.ts
@@ -22,7 +22,7 @@ type CachedValues = {
 
 const cache = new WeakMap<FastlyApiContext, CachedValues>();
 
-export async function getKVStoreIdForNameMap(fastlyApiContext: FastlyApiContext): Promise<Record<string, string>> {
+export async function getKVStoreIdForNameMap(fastlyApiContext: FastlyApiContext) {
   const cacheEntry = cache.get(fastlyApiContext);
 
   let kvStoreNameMap = cacheEntry?.kvStoreNameMap;
@@ -42,15 +42,16 @@ export async function getKVStoreIdForNameMap(fastlyApiContext: FastlyApiContext)
   return kvStoreNameMap;
 }
 
-export async function getKVStoreIdForName(fastlyApiContext: FastlyApiContext, kvStoreName: string): Promise<string | null> {
+export async function getKVStoreIdForName(fastlyApiContext: FastlyApiContext, kvStoreName: string) {
 
   const kvStoreNameMap = await getKVStoreIdForNameMap(fastlyApiContext);
   return kvStoreNameMap[kvStoreName] ?? null;
+
 }
 
 function createArrayGetter<TEntry>() {
   return function<TFn extends (...args:any[]) => string>(fn: TFn) {
-    return async function(fastlyApiContext: FastlyApiContext, ...args: Parameters<TFn>): Promise<TEntry[]> {
+    return async function(fastlyApiContext: FastlyApiContext, ...args: Parameters<TFn>) {
       const results: TEntry[] = [];
 
       let cursor: string | null = null;
@@ -86,7 +87,7 @@ function createArrayGetter<TEntry>() {
 
 const _getKVStoreInfos = createArrayGetter<KVStoreInfo>()(() => `/resources/stores/kv`);
 
-export async function getKVStoreInfos(fastlyApiContext: FastlyApiContext): Promise<KVStoreInfo[]> {
+export async function getKVStoreInfos(fastlyApiContext: FastlyApiContext) {
 
   const cacheEntry = cache.get(fastlyApiContext);
 
@@ -104,7 +105,7 @@ export async function getKVStoreInfos(fastlyApiContext: FastlyApiContext): Promi
 
 export const _getKVStoreKeys = createArrayGetter<KVStoreEntryInfo>()((kvStoreId: string) => `/resources/stores/kv/${encodeURIComponent(kvStoreId)}/keys`);
 
-export async function getKVStoreKeys(fastlyApiContext: FastlyApiContext, kvStoreName: string): Promise<KVStoreEntryInfo[] | null> {
+export async function getKVStoreKeys(fastlyApiContext: FastlyApiContext, kvStoreName: string) {
 
   const kvStoreId = await getKVStoreIdForName(fastlyApiContext, kvStoreName);
   if (kvStoreId == null) {
@@ -114,7 +115,7 @@ export async function getKVStoreKeys(fastlyApiContext: FastlyApiContext, kvStore
   return await _getKVStoreKeys(fastlyApiContext, kvStoreId);
 }
 
-export async function kvStoreEntryExists(fastlyApiContext: FastlyApiContext, kvStoreName: string, key: string): Promise<boolean> {
+export async function kvStoreEntryExists(fastlyApiContext: FastlyApiContext, kvStoreName: string, key: string) {
 
   const kvStoreId = await getKVStoreIdForName(fastlyApiContext, kvStoreName);
   if (kvStoreId == null) {
@@ -130,7 +131,7 @@ export async function kvStoreEntryExists(fastlyApiContext: FastlyApiContext, kvS
 }
 
 const encoder = new TextEncoder();
-export async function kvStoreSubmitFile(fastlyApiContext: FastlyApiContext, kvStoreName: string, key: string, data: Uint8Array | string): Promise<void> {
+export async function kvStoreSubmitFile(fastlyApiContext: FastlyApiContext, kvStoreName: string, key: string, data: Uint8Array | string) {
 
   const kvStoreId = await getKVStoreIdForName(fastlyApiContext, kvStoreName);
   if (kvStoreId == null) {
@@ -154,7 +155,7 @@ export async function kvStoreSubmitFile(fastlyApiContext: FastlyApiContext, kvSt
 
 }
 
-export async function kvStoreDeleteFile(fastlyApiContext: FastlyApiContext, kvStoreName: string, key: string): Promise<void> {
+export async function kvStoreDeleteFile(fastlyApiContext: FastlyApiContext, kvStoreName: string, key: string) {
 
   const kvStoreId = await getKVStoreIdForName(fastlyApiContext, kvStoreName);
   if (kvStoreId == null) {

--- a/src/cli/util/retryable.ts
+++ b/src/cli/util/retryable.ts
@@ -1,0 +1,62 @@
+let _globalBackoffUntil = 0;
+
+const retryableSymbol = Symbol();
+export function makeRetryable(error: Error) {
+  (error as any)[retryableSymbol] = true;
+  return error;
+}
+export function isRetryableError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (error as any)[retryableSymbol] ?? false;
+}
+
+type RetryWithBackoffOptions = {
+  maxRetries?: number,
+  initialDelay?: number,
+  onAttempt?: (attempt: number) => void,
+  onSuccess?: (attempt: number) => void,
+  onRetry?: (attempt: number, err: unknown, delay: number) => void,
+};
+export async function attemptWithRetries<TResult>(
+  fn: () => Promise<TResult>,
+  options: RetryWithBackoffOptions = {},
+) {
+  const {
+    maxRetries = 5,
+    initialDelay = 60000,
+    onAttempt,
+    onSuccess,
+    onRetry,
+  } = options;
+
+  let attempt = 0;
+  let result: TResult;
+
+  while (true) {
+    const waitTime = _globalBackoffUntil - Date.now();
+    if (waitTime > 0) {
+      await new Promise(res => setTimeout(res, waitTime));
+    }
+
+    try {
+      onAttempt?.(attempt);
+      result = await fn();
+      onSuccess?.(attempt);
+      break;
+    } catch (err) {
+      if (!isRetryableError(err) || attempt >= maxRetries) {
+        throw err;
+      }
+
+      const delay = initialDelay * (attempt + 1);
+      _globalBackoffUntil = Date.now() + delay;
+      onRetry?.(attempt, err, delay);
+    }
+
+    attempt++;
+  }
+
+  return result;
+}


### PR DESCRIPTION
This PR makes the following changes:

1. Node.js 20 is now a requirement. This is a version of Node.js where fetch() is marked as "Stable"

2. `callFastlyApi` now throws `FetchError`, a custom error type that includes the status code. This simplifies error handling logic as error status codes and connection problems can be handled/retried together.

3. `retryable` can mark certain errors as "possible to retry". This includes certain error codes as well as problems with the network (fetch itself failing).

4. A "fetch pool" of 12 concurrent workers all submitting to the KV store in parallel. This speeds up publishes. Whenever a submit fails, there is a backoff for retries so that the system tries again.

5. Some TypeScript code cleanup

Fixes #29 