### PR TITLE
Correct handle URL encoding in path name

### DIFF
--- a/src/server/publisher-server.ts
+++ b/src/server/publisher-server.ts
@@ -272,7 +272,7 @@ export class PublisherServer {
     }
 
     const url = new URL(request.url);
-    const pathname = url.pathname;
+    const pathname = decodeURI(url.pathname);
 
     const asset = this.getMatchingAsset(pathname);
     if (asset != null) {


### PR DESCRIPTION
The built-in server used `new URL(request.url).pathname` to build the "asset key" by which to look up content assets.

If the request contains characters that are not safe for URLs, request.url will have those characters url-encoded.

This PR performs decodeURI on the path before processing it with the built-in server.
