### PR TITLE
Don't compress binary files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,17 @@ If the files in `--root-dir` have changed, then a new set of files will be publi
 
 ### Content Compression
 
-During publishing, this tool supports pre-compression of content. By default, your assets are compressed using the Brotli
-and gzip algorithms, and then stored alongside the original files in your Wasm binary (or [KV Store](#kv-store)).
+During publishing, this tool supports pre-compression of content. By default, your assets for select content types are
+compressed using the Brotli and gzip algorithms, and then stored alongside the original files in your Wasm binary (or
+[KV Store](#kv-store)).
+
+The content types that are compressed include any that are considered `text` types, as well as certain binary types that
+expect to see a benefit of being compressed.
+
+* Compressed text types: `.txt` `.html` `.xml` `.json` `.map` `.js` `.css` `.svg`
+* Compressed binary types: `.bmp` `.tar`
+
+To configure these content types, use the `contentTypes` field of the [`static-publish.rc.js` config file](#static-publish-rc).
 
 > [!IMPORTANT]
 > By default, pre-compressed content assets are not generated when the KV Store is not used.
@@ -412,15 +421,19 @@ And that's it! It should be possible to run this task to clean up once in a whil
   * `contentType` - The content type header to apply when serving an asset of this content type definition.
   * `text` - If `true`, this content type definition is considered to contain textual data. This makes `.text()` and `.json()`
     available for calling on store entries. If not specified, this is treated as `false`.
-
-  For example, to add a custom content type `application/x-custom` for files that have a `.custom` extension, and not treat
-  it as a text file, add the following to your `static-publish.rc.js` file:
+  * `precompressAsset` - When `true`, this tool generates pre-compressed versions of content assets and serves them to user
+    agents that assert an appropriate `Accept` header. See [Content Compression*](#content-compression) for details. If
+    not specified, this is `true` if `text` is `true`, and `false` if `text` is not `true`.
+ 
+  For example, to add a custom content type `application/x-custom` for files that have a `.custom` extension, not treat
+  it as a text file, but precompress it during the generation of the application, add the following to your
+  `static-publish.rc.js` file:
 
     ```javascript
     const config = {
       /* ... other config ... */
       contentTypes: [
-        { test: /\.custom$/, contentType: 'application/x-custom', text: false },
+        { test: /\.custom$/, contentType: 'application/x-custom', text: false, precompressAsset: true },
       ],
     };
     ```

--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -303,6 +303,7 @@ export async function buildStaticLoader(commandLineValues: commandLineArgs.Comma
       contentTypeTestResult = {
         text: false,
         contentType: 'application/octet-stream',
+        precompressAsset: false,
       };
       if (displayFrameworkWarnings) {
         console.log('⚠️ Notice: Unknown file type ' + assetKey + '. Treating as binary file.');
@@ -403,6 +404,7 @@ export async function buildStaticLoader(commandLineValues: commandLineArgs.Comma
       assetKey,
       contentType,
       text,
+      precompressAsset,
       hash,
       size,
       lastModifiedTime,
@@ -429,7 +431,7 @@ export async function buildStaticLoader(commandLineValues: commandLineArgs.Comma
     async function prepareCompressedVersions(contentCompressions: ContentCompressionTypes[], func: PrepareCompressionVersionFunc) {
       for (const alg of contentCompressions) {
         const compressTo = algs[alg];
-        if (compressTo != null) {
+        if (precompressAsset && compressTo != null) {
 
           const staticFilePath = `${staticContentFilePath}_${alg}`;
           if (await compressTo(file, staticFilePath, text)) {

--- a/src/cli/commands/build-static.ts
+++ b/src/cli/commands/build-static.ts
@@ -427,12 +427,10 @@ export async function buildStaticLoader(commandLineValues: commandLineArgs.Comma
 
     type PrepareCompressionVersionFunc = (alg: ContentCompressionTypes, staticFilePath: string, hash: string, size: number) => void;
     async function prepareCompressedVersions(contentCompressions: ContentCompressionTypes[], func: PrepareCompressionVersionFunc) {
-      for (const alg of contentCompression) {
+      for (const alg of contentCompressions) {
         const compressTo = algs[alg];
         if (compressTo != null) {
 
-          // Even for items that are not inlined, compressed copies of the file are
-          // always created in the static content directory.
           const staticFilePath = `${staticContentFilePath}_${alg}`;
           if (await compressTo(file, staticFilePath, text)) {
             console.log(`✔️ Compressed ${text ? 'text' : 'binary'} asset "${file}" to "${staticFilePath}" [${alg}].`)
@@ -453,6 +451,8 @@ export async function buildStaticLoader(commandLineValues: commandLineArgs.Comma
       fs.cpSync(file, staticFilePath);
       console.log(`✔️ Copied ${text ? 'text' : 'binary'} asset "${file}" to "${staticFilePath}".`);
 
+      // 'prepareCompressedVersions' uses the static content directory for compressed copies,
+      // even for 'inline' files.
       const compressedFileInfos: CompressedFileInfos<ContentFileInfoForWasmInline> = {};
       await prepareCompressedVersions(contentCompression, (alg, staticFilePath, hash, size) => {
         compressedFileInfos[alg] = { staticFilePath, hash, size };

--- a/src/types/content-types.ts
+++ b/src/types/content-types.ts
@@ -11,9 +11,14 @@ export type ContentTypeDef = {
   // Whether this content type represents a text value encoded in utf-8.
   // If so, conveniences can be provided.
   text?: boolean,
+
+  // Binary formats are usually not candidates for compression, but certain
+  // types can benefit from it.
+  precompressAsset?: boolean,
 };
 
 export type ContentTypeTestResult = {
   contentType: string,
   text: boolean,
+  precompressAsset: boolean,
 };

--- a/src/util/content-types.ts
+++ b/src/util/content-types.ts
@@ -15,7 +15,7 @@ const defaultContentTypes: ContentTypeDef[] = [
   { test: /\.svg$/, contentType: 'image/svg+xml', text: true },
 
   // Binary formats
-  { test: /\.bmp$/, contentType: 'image/bmp', text: false },
+  { test: /\.bmp$/, contentType: 'image/bmp', text: false, precompressAsset: true, },
   { test: /\.png$/, contentType: 'image/png', text: false },
   { test: /\.gif$/, contentType: 'image/gif', text: false },
   { test: /\.jp(e)?g$/, contentType: 'image/jpeg', text: false },
@@ -29,7 +29,7 @@ const defaultContentTypes: ContentTypeDef[] = [
   { test: /\.mpeg$/, contentType: 'video/mpeg', text: false },
   { test: /\.webm$/, contentType: 'video/webm', text: false },
   { test: /\.pdf$/, contentType: 'application/pdf', text: false },
-  { test: /\.tar$/, contentType: 'application/x-tar', text: false },
+  { test: /\.tar$/, contentType: 'application/x-tar', text: false, precompressAsset: true, },
   { test: /\.zip$/, contentType: 'application/zip', text: false },
   { test: /\.eot$/, contentType: 'application/vnd.ms-fontobject', text: false },
   { test: /\.otf$/, contentType: 'font/otf', text: false },
@@ -105,7 +105,11 @@ export function testFileContentType(contentTypes: ContentTypeDef[] | null | unde
       matched = contentType.test(assetKey);
     }
     if(matched) {
-      return { contentType: contentType.contentType, text: Boolean(contentType.text ?? false) };
+      return {
+        contentType: contentType.contentType,
+        text: Boolean(contentType.text ?? false),
+        precompressAsset: Boolean(contentType.precompressAsset ?? contentType.text ?? false)
+      };
     }
   }
   return null;


### PR DESCRIPTION
We don't get a lot out of pre-compressing most binary types.

So we will disable pre-compression for most binary types, allowing for configuration.

```markdown
During publishing, this tool supports pre-compression of content. By default, your assets for select content types are
compressed using the Brotli and gzip algorithms, and then stored alongside the original files in your Wasm binary or KV Store.

The content types that are compressed include any that are considered `text` types, as well as certain binary types that
expect to see a benefit of being compressed.

* Compressed text types: `.txt` `.html` `.xml` `.json` `.map` `.js` `.css` `.svg`
* Compressed binary types: `.bmp` `.tar`

To configure these content types, use the `contentTypes` field of the `static-publish.rc.js` config file.
```

```markdown
  * `precompressAsset` - When `true`, this tool generates pre-compressed versions of content assets and serves them to user
    agents that assert an appropriate `Accept` header. See Content Compression for details. If
    not specified, this is `true` if `text` is `true`, and `false` if `text` is not `true`.
```

for example:
```javascript
const config = {
  /* ... other config ... */
  contentTypes: [
    { test: /\.custom$/, contentType: 'application/x-custom', text: false, precompressAsset: true },
  ],
};
```

Fixes #27 
