### PR TITLE
fix: handle symlinks properly in file enumeration

### DIFF
--- a/src/cli/util/files.ts
+++ b/src/cli/util/files.ts
@@ -52,6 +52,18 @@ function enumerateFilesWorker(results: string[], dir: string, opts: EnumerateFil
 
     if (entry.isDirectory()) {
       enumerateFilesWorker(results, fullpath, opts);
+    } else if (entry.isSymbolicLink()) {
+      try {
+        const stats = fs.statSync(fullpath);
+        if (stats.isDirectory()) {
+          enumerateFilesWorker(results, fullpath, opts);
+        } else if (stats.isFile()) {
+          results.push(fullpath);
+        }
+      } catch (err) {
+        // Skip broken symlinks
+        continue;
+      }
     } else {
       results.push(fullpath);
     }


### PR DESCRIPTION
Add proper symlink handling to prevent errors when encountering symbolic links during file enumeration. The fix resolves symlinks to their target and processes them as either directories or files as appropriate, while gracefully skipping broken symlinks.

🤖 Generated with [Claude Code](https://claude.ai/code)

--

n.b., I ( a human) reviewed and tested this code and it does what I intended it to do.