### PR TITLE
feat: add WebAssembly content type support

### DIFF
--- a/src/cli/util/content-types.ts
+++ b/src/cli/util/content-types.ts
@@ -36,6 +36,7 @@ const defaultContentTypes: ContentTypeDef[] = [
   { test: /\.pdf$/, contentType: 'application/pdf', text: false },
   { test: /\.tar$/, contentType: 'application/x-tar', text: false, precompressAsset: true, },
   { test: /\.zip$/, contentType: 'application/zip', text: false },
+  { test: /\.wasm$/, contentType: 'application/wasm', text: false },
   { test: /\.eot$/, contentType: 'application/vnd.ms-fontobject', text: false },
   { test: /\.otf$/, contentType: 'font/otf', text: false },
   { test: /\.ttf$/, contentType: 'font/ttf', text: false },


### PR DESCRIPTION
- Add application/wasm MIME type for .wasm files to default content types

https://webassembly.github.io/spec/web-api/#streaming-modules says:

> If mimeType is not a byte-case-insensitive match for `application/wasm`,
> reject returnValue with a TypeError and abort these substeps.