### PR TITLE
Fix --auto-ext default being lost during scaffolding

### DIFF
--- a/src/cli/commands/scaffold/index.ts
+++ b/src/cli/commands/scaffold/index.ts
@@ -252,7 +252,7 @@ function buildOptions(
   }
 
   {
-    let autoExt: string[] = [];
+    let autoExt: string[] | undefined;
     const autoExtValue = commandLineOptions['auto-ext'];
 
     const asArray = Array.isArray(autoExtValue) ? autoExtValue : [ autoExtValue ];


### PR DESCRIPTION
v8 counterpart of #56 (same fix, against `v8` instead of `main` — the defect is present verbatim on this branch).

## Problem

When scaffolding an app without passing `--auto-ext`, the generated `publish-content.config.js` contains `autoExt: []` instead of the documented default of `[ '.html', '.htm' ]`. Auto-extension resolution is therefore silently off for every app scaffolded without the flag — a request for `/about` won't fall back to `/about.html`.

Note the asymmetry with `autoIndex`, which does get its default:

```js
  server: {
    ...
    autoExt: [],                              // ← should be [".html",".htm"]
    autoIndex: ["index.html","index.htm"],    // ← correct
  },
```

## Cause

In `buildOptions()`, `autoExt` is initialized to `[]`:

```js
let autoExt: string[] = [];
```

When `--auto-ext` is absent, `asArray` is `[undefined]`, so the `every(x => typeof x === 'string')` guard fails and `autoExt` keeps its `[]` initializer. The trailing `if (autoExt !== undefined)` check then always passes and overwrites the default from `defaultOptions`.

The neighboring `autoIndex` block declares `let autoIndex: string[] | undefined;` with no initializer, which is why it behaves correctly.

## Fix

Declare `autoExt` the same way as `autoIndex`, so an absent flag leaves the default in place.

## Verification

`npm run build` clean (both `compile:cli` and `compile:server`). Scaffolded with no `--auto-ext`, before vs. after:

```
before:  autoExt: [],
after:   autoExt: [".html",".htm"],
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)