### PR TITLE
Fix scaffolding writing SPA/404 fallbacks that do not exist

### DIFF
--- a/src/cli/commands/scaffold/index.ts
+++ b/src/cli/commands/scaffold/index.ts
@@ -613,6 +613,7 @@ export async function action(actionArgs: string[]) {
     } else if (!fs.existsSync(spaFilename)) {
       console.log(`⚠️ Warning: Ignoring specified SPA file '${SPA}' does not exist.`);
       console.log(`  * ${rootRelative(spaFilename)} does not exist.`);
+      spaFilename = undefined;
     }
   }
 
@@ -629,6 +630,7 @@ export async function action(actionArgs: string[]) {
     } else if (!fs.existsSync(notFoundPageFilename)) {
       console.log(`⚠️ Warning: Ignoring specified Not Found file '${NOT_FOUND_PAGE}' as it does not exist.`);
       console.log(`  * ${rootRelative(notFoundPageFilename)} does not exist.`);
+      notFoundPageFilename = undefined;
     }
   }
 


### PR DESCRIPTION
v8 counterpart of #57 (same fix, against `v8` instead of `main` — the defect is present verbatim on this branch).

## Problem

Scaffolding a site that has no `404.html` prints a warning saying the 404 page is being ignored, and then writes it into the generated config anyway:

```
⚠️ Warning: Ignoring specified Not Found file '[public-dir]/404.html' as it does not exist.
  * ./public/404.html does not exist.
...
404 Page                       : ./public/404.html
```

```js
  server: {
    ...
    notFoundPageFile: "/404.html",   // ← should be false
  },
```

Since `notFoundPage` defaults to `[public-dir]/404.html`, this affects every app scaffolded without a `404.html` — i.e. the default path, not an edge case.

## Cause

Both fallback-file validation blocks clear the filename when the path is outside the root dir, but the "file doesn't exist" branch only logs:

```js
    if (!notFoundPageFilename.startsWith(rootDir)) {
      ...
      notFoundPageFilename = undefined;      // cleared
    } else if (!fs.existsSync(notFoundPageFilename)) {
      ...                                     // logged, but not cleared
    }
```

Downstream, the code assumes the opposite — its comment reads *"We've already established notFoundPageFilename.startsWith(rootDir) and that it exists"* before slicing it into `notFoundPageFile`.

## Fix

Set the filename to `undefined` in the non-existent-file branch so the generated config gets `false`.

I fixed the identical defect in the adjacent `spaFile` block in the same commit — same root cause, two lines apart. It's less visible because `spa` has no default, so it only triggers when `--spa` is passed with a path that doesn't exist (verified: it produced `spaFile: "/spa.html"`).

## Impact note

Serving behavior was already protected: `publish-content` re-validates `spaFile`/`notFoundPageFile` against the published index and nulls out anything missing or not `text/html` (`publish-content.ts:533-556` on this branch). So this is a fidelity bug in the generated config rather than a broken 404 at runtime — the file said one thing, the warning said another, and a user editing that config would be misled.

## Verification

`npm run build` clean (both `compile:cli` and `compile:server`). With no `404.html` and `--spa` pointing at a missing file:

```
before:  spaFile: "/spa.html",   notFoundPageFile: "/404.html",
after:   spaFile: false,         notFoundPageFile: false,
```

With both files present, unchanged: `spaFile: "/spa.html"`, `notFoundPageFile: "/404.html"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)