### PR TITLE
CLI v16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "3.888.0",
-        "@fastly/cli": "^15.2.0",
+        "@fastly/cli": "^16.0.0",
         "command-line-args": "^5.2.1",
         "glob-to-regexp": "^0.4.1",
         "toml": "^3.0.0"
@@ -1545,9 +1545,9 @@
       }
     },
     "node_modules/@fastly/cli": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli/-/cli-15.2.0.tgz",
-      "integrity": "sha512-6Ax2AAAP7dQLBCLcK7Bl5xaa3YjDWlknoGqdergnyihevp30Jx91h5FARujhS+00dqmf00tLzeeZGdn0ywSoOA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli/-/cli-16.0.0.tgz",
+      "integrity": "sha512-BAjvjUXXYoMwyAmiDAGW7IkaI/LsUiDi6CZfNafgMpqoG+IkSuYjVx4RYwxyDfWWrOzRCaMHOtgLixISkBE79A==",
       "license": "Apache-2.0",
       "bin": {
         "fastly": "fastly.js"
@@ -1556,20 +1556,20 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@fastly/cli-darwin-arm64": "=15.2.0",
-        "@fastly/cli-darwin-x64": "=15.2.0",
-        "@fastly/cli-linux-arm64": "=15.2.0",
-        "@fastly/cli-linux-x32": "=15.2.0",
-        "@fastly/cli-linux-x64": "=15.2.0",
-        "@fastly/cli-win32-arm64": "=15.2.0",
-        "@fastly/cli-win32-x32": "=15.2.0",
-        "@fastly/cli-win32-x64": "=15.2.0"
+        "@fastly/cli-darwin-arm64": "=16.0.0",
+        "@fastly/cli-darwin-x64": "=16.0.0",
+        "@fastly/cli-linux-arm64": "=16.0.0",
+        "@fastly/cli-linux-x32": "=16.0.0",
+        "@fastly/cli-linux-x64": "=16.0.0",
+        "@fastly/cli-win32-arm64": "=16.0.0",
+        "@fastly/cli-win32-x32": "=16.0.0",
+        "@fastly/cli-win32-x64": "=16.0.0"
       }
     },
     "node_modules/@fastly/cli-darwin-arm64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-arm64/-/cli-darwin-arm64-15.2.0.tgz",
-      "integrity": "sha512-A+3nSKZXOKVM8o4lbQamMdcAdqdkqk2WXDoBXAGuFb55FpANgLiGOOpqXKrbaxIZTkAkI5Q006XUErk19v6uyw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-arm64/-/cli-darwin-arm64-16.0.0.tgz",
+      "integrity": "sha512-xrmTC/D71zO0DgwE5EdnQGArQyTO6nwdfk4jP+wxk1W0gh1tl5KB4nwXXRnv9+5GYnUhHpjwQAefjY5388GfIg==",
       "cpu": [
         "arm64"
       ],
@@ -1583,9 +1583,9 @@
       }
     },
     "node_modules/@fastly/cli-darwin-x64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-x64/-/cli-darwin-x64-15.2.0.tgz",
-      "integrity": "sha512-RcbBIRZp28zslJYPO9vNd22I6v0+xtQ9FuJ822JKMCOZxWMFiH7ZstU7gVuVV9jr+FQ9YQ4TCk3+U0t72ofh7A==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-x64/-/cli-darwin-x64-16.0.0.tgz",
+      "integrity": "sha512-V1HbM8PPBaY6BXOvxlHfhKbku9zjY7Bv/j5cRTR9QIiDO391Ls/oCL0M70hsmDooAGe+pSa1+eZupFGmz9lJEQ==",
       "cpu": [
         "x64"
       ],
@@ -1599,9 +1599,9 @@
       }
     },
     "node_modules/@fastly/cli-linux-arm64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-arm64/-/cli-linux-arm64-15.2.0.tgz",
-      "integrity": "sha512-TvqlDq3zl6/KQTv0pAdel9/PM33kMwY7wqisWFmZux1Yy4eP8+qmcGlpLFCapt9DGovqwipyQp37dESa7Q0DEA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-arm64/-/cli-linux-arm64-16.0.0.tgz",
+      "integrity": "sha512-N3fqvKae7wngDnkAdxyxIHfVaphEf+uwIfDhlDnGzV68ZHjx5kd91/5dP3vT/DDgM6t4sd/S4g1gtECAlYV26w==",
       "cpu": [
         "arm64"
       ],
@@ -1615,9 +1615,9 @@
       }
     },
     "node_modules/@fastly/cli-linux-x32": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x32/-/cli-linux-x32-15.2.0.tgz",
-      "integrity": "sha512-Xh5lYf1dBIBk0iJOCx53w4F9whaK/eW182IwSxearW3azP0cuf2HPVLyFV3SbVvg2hwE0EULpd7HtE9s/kQanw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x32/-/cli-linux-x32-16.0.0.tgz",
+      "integrity": "sha512-iDIa5mLqV/8wt2AWdnS1lvOm9WHmX7ziVBHSIbAHj7WHRNo7HZHTbSWWdZiEoGIEgKyADDLl1Qp1XKYXe8bzow==",
       "cpu": [
         "x32"
       ],
@@ -1631,9 +1631,9 @@
       }
     },
     "node_modules/@fastly/cli-linux-x64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x64/-/cli-linux-x64-15.2.0.tgz",
-      "integrity": "sha512-YF42ww2GQmFkizGVsT6k8k8wIjK6C12EXTWA6rJ6GwgLrv/Jp/HXdIVK7Q8oqU5P1XmC7BRm16t++IWSo5Mlqg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x64/-/cli-linux-x64-16.0.0.tgz",
+      "integrity": "sha512-na2GNXTF+wizFcTJdEC5TGeyps8vgYBRdh+TThL+TVCUEIjmSUpMoSz5Ud6hxt/G4m03FilRlnULrq+sE4u7qw==",
       "cpu": [
         "x64"
       ],
@@ -1647,9 +1647,9 @@
       }
     },
     "node_modules/@fastly/cli-win32-arm64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-arm64/-/cli-win32-arm64-15.2.0.tgz",
-      "integrity": "sha512-h+WsiSS4uSwDujGb4p31lbVG+OUozixPMqQ/nbgAtI1ZJMQnb6S9B+4aOhLrcbLzmwt+iyjGLsyeb+Xrumd7Lw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-arm64/-/cli-win32-arm64-16.0.0.tgz",
+      "integrity": "sha512-Jw8tfN3MPQLHduOpYzV4bh7gEnymnHkLIamT9Fupczl+50PFDcZkyzhkA5CqVo7nql5adywgnqWRBq/C1OMCPA==",
       "cpu": [
         "arm64"
       ],
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/@fastly/cli-win32-x32": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x32/-/cli-win32-x32-15.2.0.tgz",
-      "integrity": "sha512-kDj/dOxAquEpevcyIvRTHSy8ZnjtVpmrIWk6EpGd2gr4hKVuv2y9omuBGjVkX1k9lF3qXkTcfFwaBk4H47tVwg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x32/-/cli-win32-x32-16.0.0.tgz",
+      "integrity": "sha512-bMyh697yK0iHFe/KoJFRZ8o/Wk1DQ8hyBAGxjSg2FHjp6xEyOTcNH/xwzuYB/dCVni2pF/G49OOUiDhMa2leWA==",
       "cpu": [
         "x32"
       ],
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/@fastly/cli-win32-x64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x64/-/cli-win32-x64-15.2.0.tgz",
-      "integrity": "sha512-86VbuGO4fWU0vY8Zy+OQzj+AhSTdE2lr7BO/4vCvkT5qwqM+L+hy+YUnLyMih/x8t+oDXegMjfCyETcIwUy9uA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x64/-/cli-win32-x64-16.0.0.tgz",
+      "integrity": "sha512-U2MznzAog0AfBW5YCp+fKj1PpY/zyB0dzs/4MtllQIfKPRbamLAt0TZp2jpJHnAiG1fgUve79gjdn0UH9rREZA==",
       "cpu": [
         "x64"
       ],
@@ -5264,66 +5264,66 @@
       "optional": true
     },
     "@fastly/cli": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli/-/cli-15.2.0.tgz",
-      "integrity": "sha512-6Ax2AAAP7dQLBCLcK7Bl5xaa3YjDWlknoGqdergnyihevp30Jx91h5FARujhS+00dqmf00tLzeeZGdn0ywSoOA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli/-/cli-16.0.0.tgz",
+      "integrity": "sha512-BAjvjUXXYoMwyAmiDAGW7IkaI/LsUiDi6CZfNafgMpqoG+IkSuYjVx4RYwxyDfWWrOzRCaMHOtgLixISkBE79A==",
       "requires": {
-        "@fastly/cli-darwin-arm64": "=15.2.0",
-        "@fastly/cli-darwin-x64": "=15.2.0",
-        "@fastly/cli-linux-arm64": "=15.2.0",
-        "@fastly/cli-linux-x32": "=15.2.0",
-        "@fastly/cli-linux-x64": "=15.2.0",
-        "@fastly/cli-win32-arm64": "=15.2.0",
-        "@fastly/cli-win32-x32": "=15.2.0",
-        "@fastly/cli-win32-x64": "=15.2.0"
+        "@fastly/cli-darwin-arm64": "=16.0.0",
+        "@fastly/cli-darwin-x64": "=16.0.0",
+        "@fastly/cli-linux-arm64": "=16.0.0",
+        "@fastly/cli-linux-x32": "=16.0.0",
+        "@fastly/cli-linux-x64": "=16.0.0",
+        "@fastly/cli-win32-arm64": "=16.0.0",
+        "@fastly/cli-win32-x32": "=16.0.0",
+        "@fastly/cli-win32-x64": "=16.0.0"
       }
     },
     "@fastly/cli-darwin-arm64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-arm64/-/cli-darwin-arm64-15.2.0.tgz",
-      "integrity": "sha512-A+3nSKZXOKVM8o4lbQamMdcAdqdkqk2WXDoBXAGuFb55FpANgLiGOOpqXKrbaxIZTkAkI5Q006XUErk19v6uyw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-arm64/-/cli-darwin-arm64-16.0.0.tgz",
+      "integrity": "sha512-xrmTC/D71zO0DgwE5EdnQGArQyTO6nwdfk4jP+wxk1W0gh1tl5KB4nwXXRnv9+5GYnUhHpjwQAefjY5388GfIg==",
       "optional": true
     },
     "@fastly/cli-darwin-x64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-x64/-/cli-darwin-x64-15.2.0.tgz",
-      "integrity": "sha512-RcbBIRZp28zslJYPO9vNd22I6v0+xtQ9FuJ822JKMCOZxWMFiH7ZstU7gVuVV9jr+FQ9YQ4TCk3+U0t72ofh7A==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-x64/-/cli-darwin-x64-16.0.0.tgz",
+      "integrity": "sha512-V1HbM8PPBaY6BXOvxlHfhKbku9zjY7Bv/j5cRTR9QIiDO391Ls/oCL0M70hsmDooAGe+pSa1+eZupFGmz9lJEQ==",
       "optional": true
     },
     "@fastly/cli-linux-arm64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-arm64/-/cli-linux-arm64-15.2.0.tgz",
-      "integrity": "sha512-TvqlDq3zl6/KQTv0pAdel9/PM33kMwY7wqisWFmZux1Yy4eP8+qmcGlpLFCapt9DGovqwipyQp37dESa7Q0DEA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-arm64/-/cli-linux-arm64-16.0.0.tgz",
+      "integrity": "sha512-N3fqvKae7wngDnkAdxyxIHfVaphEf+uwIfDhlDnGzV68ZHjx5kd91/5dP3vT/DDgM6t4sd/S4g1gtECAlYV26w==",
       "optional": true
     },
     "@fastly/cli-linux-x32": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x32/-/cli-linux-x32-15.2.0.tgz",
-      "integrity": "sha512-Xh5lYf1dBIBk0iJOCx53w4F9whaK/eW182IwSxearW3azP0cuf2HPVLyFV3SbVvg2hwE0EULpd7HtE9s/kQanw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x32/-/cli-linux-x32-16.0.0.tgz",
+      "integrity": "sha512-iDIa5mLqV/8wt2AWdnS1lvOm9WHmX7ziVBHSIbAHj7WHRNo7HZHTbSWWdZiEoGIEgKyADDLl1Qp1XKYXe8bzow==",
       "optional": true
     },
     "@fastly/cli-linux-x64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x64/-/cli-linux-x64-15.2.0.tgz",
-      "integrity": "sha512-YF42ww2GQmFkizGVsT6k8k8wIjK6C12EXTWA6rJ6GwgLrv/Jp/HXdIVK7Q8oqU5P1XmC7BRm16t++IWSo5Mlqg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x64/-/cli-linux-x64-16.0.0.tgz",
+      "integrity": "sha512-na2GNXTF+wizFcTJdEC5TGeyps8vgYBRdh+TThL+TVCUEIjmSUpMoSz5Ud6hxt/G4m03FilRlnULrq+sE4u7qw==",
       "optional": true
     },
     "@fastly/cli-win32-arm64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-arm64/-/cli-win32-arm64-15.2.0.tgz",
-      "integrity": "sha512-h+WsiSS4uSwDujGb4p31lbVG+OUozixPMqQ/nbgAtI1ZJMQnb6S9B+4aOhLrcbLzmwt+iyjGLsyeb+Xrumd7Lw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-arm64/-/cli-win32-arm64-16.0.0.tgz",
+      "integrity": "sha512-Jw8tfN3MPQLHduOpYzV4bh7gEnymnHkLIamT9Fupczl+50PFDcZkyzhkA5CqVo7nql5adywgnqWRBq/C1OMCPA==",
       "optional": true
     },
     "@fastly/cli-win32-x32": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x32/-/cli-win32-x32-15.2.0.tgz",
-      "integrity": "sha512-kDj/dOxAquEpevcyIvRTHSy8ZnjtVpmrIWk6EpGd2gr4hKVuv2y9omuBGjVkX1k9lF3qXkTcfFwaBk4H47tVwg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x32/-/cli-win32-x32-16.0.0.tgz",
+      "integrity": "sha512-bMyh697yK0iHFe/KoJFRZ8o/Wk1DQ8hyBAGxjSg2FHjp6xEyOTcNH/xwzuYB/dCVni2pF/G49OOUiDhMa2leWA==",
       "optional": true
     },
     "@fastly/cli-win32-x64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x64/-/cli-win32-x64-15.2.0.tgz",
-      "integrity": "sha512-86VbuGO4fWU0vY8Zy+OQzj+AhSTdE2lr7BO/4vCvkT5qwqM+L+hy+YUnLyMih/x8t+oDXegMjfCyETcIwUy9uA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x64/-/cli-win32-x64-16.0.0.tgz",
+      "integrity": "sha512-U2MznzAog0AfBW5YCp+fKj1PpY/zyB0dzs/4MtllQIfKPRbamLAt0TZp2jpJHnAiG1fgUve79gjdn0UH9rREZA==",
       "optional": true
     },
     "@fastly/js-compute": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "homepage": "https://github.com/fastly/compute-js-static-publish#readme",
   "dependencies": {
     "@aws-sdk/client-s3": "3.888.0",
-    "@fastly/cli": "^15.2.0",
+    "@fastly/cli": "^16.0.0",
     "command-line-args": "^5.2.1",
     "glob-to-regexp": "^0.4.1",
     "toml": "^3.0.0"

--- a/src/cli/commands/scaffold/index.ts
+++ b/src/cli/commands/scaffold/index.ts
@@ -794,7 +794,7 @@ export async function action(actionArgs: string[]) {
     author,
     type: 'module',
     devDependencies: {
-      "@fastly/cli": "^15.2.0",
+      "@fastly/cli": "^16.0.0",
       '@fastly/compute-js-static-publish': computeJsStaticPublisherVersion,
     },
     dependencies: {


### PR DESCRIPTION
v8 counterpart of #58.

Updates `@fastly/cli` from `^15.2.0` to `^16.0.0` in both places it appears, following the same shape as this branch's own v15 bump (6333768):

- **The publisher's own dependency** (`package.json` + `package-lock.json`) — `src/cli/util/api-token.ts` imports it to locate the `fastly` binary for token lookup.
- **The scaffolded application's devDependencies** (`src/cli/commands/scaffold/index.ts`) — used by the generated `dev:start` / `fastly:deploy` scripts.

Diff footprint is identical to 6333768 (142 / 2 / 2 lines across the same three files).

**No `CHANGELOG.md` entry**, matching this branch's precedent — 6333768 ("CLI v15") didn't add one either. Note this differs from #58 on `main`, which does add one, because there the v7 lineage *does* changelog CLI bumps (`7.0.7` — "Update to CLI v15"). Happy to add an entry here if you'd rather have it.

## Verification

- `npm run build` clean (`compile:cli` + `compile:server`).
- Binary resolves and reports the new version: `Fastly CLI version v16.0.0 (34cef1b0)`.
- Scaffolded a fresh app: generated `package.json` declares `"@fastly/cli": "^16.0.0"` and `npm install` resolved 16.0.0.
- `npm run dev:publish` in the scaffolded app completed and wrote the expected local store entries (content + `br`/`gzip` variants + `_index_live` + `_settings_live`).
- `fastly profile token` — the command `loadApiToken()` shells out to — is unaffected by the bump. Its `--help` output is byte-identical between v15.2.0 and v16.0.0 (same usage, same optional `[<profile>]` arg, same `--ttl` flag), so nothing on this code path changes between the two versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)